### PR TITLE
enlazo Codigo de conducta al footer y añado contenido

### DIFF
--- a/src/content/basic/codigo-conducta.md
+++ b/src/content/basic/codigo-conducta.md
@@ -1,0 +1,69 @@
+---
+path: '/codigo-conducta/'
+title: 'Código de conducta'
+date: 2021-07-27T16:52:34+07:00
+---
+
+Python España, como asociación en torno a la que se organizan eventos de distintos tipos, quiere asegurar que todas las personas que participen en dichos eventos o comunicaciones tengan una experiencia profesional y positiva de aprendizaje, colaboración u ocio. Para ello, se espera que quien participe en la comunidad muestre respeto y cortesía hacia el resto.
+
+Al participar en la comunidad de Python España, te comprometes a fomentar una experiencia libre de acoso para todo el mundo, independientemente de la edad, dimensión corporal, discapacidad visible o invisible, etnicidad, características sexuales, identidad y expresión de género, nivel de experiencia, educación, nivel socio-económico, nacionalidad, apariencia personal, raza, religión, o identidad u orientación sexual.
+
+Este Código de Conducta detalla qué comportamientos se esperan, cuáles se rechazan y qué mecanismos hay para ayudar a una persona que esté siendo objeto de comportamientos inadecuados.
+
+## ¿Por qué un código de conducta?
+
+Siguiendo con el zen de Python, explícito mejor que implícito. Explicitar qué se espera del ambiente en cualquier evento de Python España:
+
+- Favorece que más personas sepan que son bienvenidas.
+- Evita ambigüedades.
+- Construye un clima de confianza, donde si alguien quiere reportar un incidente, sabrá que no empezaremos por cuestionarle (*victim blaming*).
+
+## Alcance
+
+Este código de conducta es aplicable a todas las personas que participen en espacios de la comunidad de Python España, ya sean en línea o presenciales. También se aplica a espacios públicos donde una persona esté en representación de la comunidad. Ejemplos de esto último incluyen el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales, o presentaciones con personas designadas en eventos en línea o no.
+
+## Nuestros estándares
+
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo para nuestra comunidad:
+
+- Demostrar empatía y amabilidad ante otras personas. No insultes o humilles a otros asistentes. Recuerda que las bromas sexistas, racistas o discriminatorias no son apropiadas. Nunca lo son.
+- Respetar las diferentes opiniones, puntos de vista y experiencias
+- Dar y aceptar adecuadamente críticas constructivas.
+- Aceptar la responsabilidad y disculparse ante quienes se vean afectados por nuestros errores, aprendiendo de la experiencia.
+- Centrarse en lo que sea mejor no sólo para nosotros como individuos, sino para la comunidad en general.
+- Usar un lenguaje inclusivo y que dé cabida a una audiencia diversa.
+- Prestar especial atención a las personas que recién llegan a la comunidad.
+
+Ejemplos de comportamiento inaceptable:
+
+- El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones sexuales de cualquier tipo.
+- Comentarios despectivos (*trolling*), insultantes o derogatorios, y ataques personales o políticos.
+- Bromas racistas, sexistas o excluyentes.
+- El acoso en público o privado.
+- Publicar información privada de otras personas, tales como direcciones físicas o de correo electrónico, sin su permiso explícito.
+- Otras conductas que puedan ser razonablemente consideradas como inapropiadas en un entorno profesional.
+
+Por acoso se entiende comentarios ofensivos relacionados con género, orientación sexual, discapacidad, apariencia física, tamaño corporal, etnia o religión, pornografía en espacios públicos, intimidación deliberada, acecho, persecución, acoso por fotografías o grabaciones, constante interrupción de charlas u otros eventos, contacto físico inapropiado y atención sexual no deseada.
+
+## Cumplimiento
+
+La administración de la comunidad es responsable de aclarar y hacer cumplir este código de conducta; en caso de que se determine un comportamiento inadecuado, tomará las acciones que considere oportunas. Éstas van desde exigir el cese del comportamiento, hasta la expulsión de una persona de un evento o de la Asociación, sin derecho a reembolso. La administración de la comunidad tendrá el derecho y la responsabilidad de eliminar, editar o rechazar mensajes, comentarios, *commits*, código, ediciones de páginas de wiki, tickets y otras contribuciones que no se alineen con este código de conducta, y comunicará las razones para sus decisiones de moderación cuando sea apropiado.
+
+## Denuncia e información de contacto
+
+Los casos de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser denunciados a las personas administradoras de la comunidad responsables del cumplimiento:
+
+- Si es un evento presencial, ponte en contacto directamente con las personas organizadoras del evento. Es muy probable que hayan publicando un código de conducta específico del evento con instrucciones de a quién acudir; te proporcionarán un espacio seguro para ayudarte.
+- Si se trata de un espacio en línea, ponte en contacto con las personas moderadoras de ese espacio.
+    - En el foro de Discourse puedes denunciar publicaciones individuales o contactar con el [grupo de moderadores](https://comunidad.es.python.org/groups/moderadores).
+    - En Telegram, a la persona propietaria del grupo u otras administradoras.
+- Para otros espacios o de forma alternativa, ponte en contacto con la Junta Directiva en [contacto@es.python.org](mailto:contacto@es.python.org).
+
+Todas las personas administradoras de la comunidad están obligadas a respetar la privacidad y la seguridad de quienes denuncien incidentes.
+
+## Atribución
+
+Este código de conducta extiende el ya existente con aportaciones de otros códigos:
+
+- La versión 2.0 en español del [Contributor Covenant](https://www.contributor-covenant.org/es/version/2/0/code_of_conduct/).
+- El código de conducta de [DjangoCon Europe 2020](https://2020.djangocon.eu/conduct/code_of_conduct/).

--- a/src/data/menus/footerMenu.json
+++ b/src/data/menus/footerMenu.json
@@ -3,5 +3,10 @@
         "name": "Home",
         "url": "/",
         "weight": 1
+    },
+    {
+        "name": "Código de conducta",
+        "url": "/codigo-conducta/",
+        "weight": 2
     }
 ]


### PR DESCRIPTION
#41 Página Código Conducta

En el último apartado de 'Atribución', he puesto directamente el enlace a la versión en español.