### PR TITLE
Revert "Crear redirecciones de URLs de la web antigua a la nueva. Fix #96"

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,8 +12,6 @@ module.exports = {
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-react-leaflet',
         'gatsby-plugin-fontawesome-css',
-        'gatsby-redirect-from',
-        'gatsby-plugin-meta-redirect',
         {
             resolve: 'gatsby-source-filesystem',
             options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,9 +16,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
 // Create pages from markdown files
 exports.createPages = ({ graphql, actions }) => {
-    const { createPage, createRedirect } = actions;
-    createRedirect({ fromPath: `/pages/asociacion.html`, toPath: `/asociacion/`, redirectInBrowser: true, isPermanent:true });
-    createRedirect({ fromPath: `/pages/ofertas-de-empleo.html`, toPath: `/empleo/`, redirectInBrowser: true, isPermanent:true });
+    const { createPage } = actions;
     return new Promise((resolve, reject) => {
         resolve(
             graphql(

--- a/package.json
+++ b/package.json
@@ -26,16 +26,15 @@
     "gatsby-plugin-fontawesome-css": "^1.1.0",
     "gatsby-plugin-google-analytics": "^3.0.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
-    "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^4.0.0",
     "gatsby-plugin-react-leaflet": "^3.0.2",
     "gatsby-plugin-sass": "^4.0.2",
-    "gatsby-redirect-from": "^0.5.0",
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-source-filesystem": "^3.0.0",
     "gatsby-transformer-json": "^3.0.0",
     "gatsby-transformer-remark": "^4.6.0",
     "leaflet": "^1.7.1",
+    "sass": "^1.43.4",
     "postcss": "^8.3.5",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
@@ -45,8 +44,7 @@
     "react-icons": "^4.2.0",
     "react-leaflet": "^3.2.1",
     "react-leaflet-markercluster": "^3.0.0-rc1",
-    "remark-parse": "^9.0.0",
-    "sass": "^1.43.4"
+    "remark-parse": "^9.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.10",


### PR DESCRIPTION
Reverts python-spain/web-ng#114

Falla porque no está actualizado el `package-lock.json`, creo.