### PR TITLE
Arreglar overflow de títulos cuando se usan palabras largas

### DIFF
--- a/src/scss/components/_title.scss
+++ b/src/scss/components/_title.scss
@@ -3,6 +3,7 @@
   font-size: 35px;
   line-height: 1.2;
   text-transform: uppercase;
+  word-break: break-word;
   @include media-breakpoint-up(lg) {
     font-size: 45px;
   }


### PR DESCRIPTION
Hola!

He visto que en versiones móviles, los títulos de las secciones pueden provocar un overflow del layout si la palabra es demasiado larga, por ejemplo "merchandising".

![Captura de pantalla de 2022-10-02 22-23-44](https://user-images.githubusercontent.com/3207982/193474774-52caaf38-3ac4-4e65-8bd6-a5ab65f42382.png)

Con la regla `word-break: break-word;` la palabra se romperá antes de provocar un overflow:

![Captura de pantalla de 2022-10-02 22-27-58](https://user-images.githubusercontent.com/3207982/193474858-e4f68cb8-0e5b-4e73-a78d-46215af64552.png)

