### PR TITLE
Añade la versión de gatsby-cli compatible con la versión de node util…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pasos para instalar e iniciar el sistema:
 1. Clonar este repo: `git clone git@github.com:python-spain/web-ng.git` y acceder al directorio.
 2. Instalar la versión de node correspondiente (en .nvmrc) `nvm install`
 3. Activar la versión de node correspondiente: `nvm use`.
-4. Instalar gatsby-cli: `npm install -g gatsby-cli`
+4. Instalar gatsby-cli: `npm install -g gatsby-cli@4.24.0`
 5. Instalar las dependencias de la web `npm ci` para instalar todo.
 6. Ejecutar `gatsby develop` para iniciar el servidor.
 7. El sitio debería ser visible en http://localhost:8000/.


### PR DESCRIPTION
…izada en los pasos para instalar e iniciar el sistema.

Al usar el comando `npm install -g gatsby-cli` se instala la última versión, la 5 y esta no es compatible con versiones de node inferiores a la 18.0. 