### PR TITLE
Remove planet link in footer

### DIFF
--- a/src/data/social.json
+++ b/src/data/social.json
@@ -18,12 +18,6 @@
         "imageDark": "/images/social/youtube-dark.svg"
     },
     {
-        "name": "Planet",
-        "link": "http://planet.es.python.org/",
-        "image": "/images/social/mundo.svg",
-        "imageDark": "/images/social/mundo-dark.svg"
-    },
-    {
         "name": "Telegram",
         "link": "https://t.me/PythonEsp",
         "image": "/images/social/telegram.svg",


### PR DESCRIPTION
Se ha borrado el planet, ya que como se habló en https://github.com/python-spain/asociacion/issues/130, no gestionamos el contenido de dicho servicio, y mejor eliminarlo.