### PR TITLE
Actualizar proceso de pago de cuota socies con GoCardless

### DIFF
--- a/src/content/basic/hazte-socio.md
+++ b/src/content/basic/hazte-socio.md
@@ -17,7 +17,7 @@ Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo. 
 
 **Opción 1: Domiciliación bancaria (recomendada)**
 
-1. Realiza el **primer pago de la cuota anual (30€)** a través de [nuestro sistema de domiciliación bancaria con GoCardless](http://xih15.mjt.lu/lnk/AWMAADy7QSIAAcp9VNgAAdoxPfQAAYCr4qMAJgaEABTcwABmG6LGEUNCF_IsTxOlnpOk-s6AZgAUrvo/6/4ZaJwwHBETxNBtB3_FfyCw/aHR0cHM6Ly9wYXkuZ29jYXJkbGVzcy5jb20vQUwwMDA0RDVBUzVQMUg).
+1. Realiza el **primer pago de la cuota anual (30€)** a través de [nuestro sistema de domiciliación bancaria con GoCardless](https://pay.gocardless.com/AL0004D5AS5P1H).
 2. Una vez completado el proceso, **no tendrás que preocuparte de nada más**. La cuota se te cobrará automáticamente cada año en la misma fecha en la que hiciste el primer pago (GoCardless te mandará un aviso unos días antes de cada cargo).
 3. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo/a socio/a"**, adjuntando:
     - Tu documento de identidad (DNI/NIE/pasaporte) escaneado
@@ -65,7 +65,7 @@ BIC/SWIFT: TRIOESMMXXX
 
 **Servicio de domiciliación automática de la asociación:**
 
-[GoCardless de Python España](http://xih15.mjt.lu/lnk/AWMAADy7QSIAAcp9VNgAAdoxPfQAAYCr4qMAJgaEABTcwABmG6LGEUNCF_IsTxOlnpOk-s6AZgAUrvo/6/4ZaJwwHBETxNBtB3_FfyCw/aHR0cHM6Ly9wYXkuZ29jYXJkbGVzcy5jb20vQUwwMDA0RDVBUzVQMUg)
+[GoCardless de Python España](https://pay.gocardless.com/AL0004D5AS5P1H)
 
 ## Quiero darme de baja
 

--- a/src/content/basic/hazte-socio.md
+++ b/src/content/basic/hazte-socio.md
@@ -13,38 +13,48 @@ Como agradecimiento por tu compromiso tendrás los siguientes beneficios, entre 
 
 ## Quiero asociarme
 
-Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo:
+Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo. Actualmente tienes **dos opciones para pagar la cuota anual**:
 
-1. Haz una transferencia de 30€[^1] a ES18 1491 0001 2230 0008 5378  indicando en el **asunto tu DNI/NIE/pasaporte** y en **destinatario "Asociación Python España"**.
-2. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo socio"** adjuntando tu documento de identidad (DNI/NIE/pasaporte) escaneado, tu teléfono de contacto, el comprobante de pago y tu IBAN[^2] para domiciliar el pago. Si lo deseas, puedes obtener una cuenta de la Asociación bajo el dominio @es.python.org[^3] confirmándolo en el correo de alta.
-3. En unos días la Junta Directiva aprobará tu solicitud y nos pondremos en contacto contigo.
+**Opción 1: Domiciliación bancaria (recomendada)**
+
+1. Realiza el **primer pago de la cuota anual (30€)** a través de [nuestro sistema de domiciliación bancaria con GoCardless](http://xih15.mjt.lu/lnk/AWMAADy7QSIAAcp9VNgAAdoxPfQAAYCr4qMAJgaEABTcwABmG6LGEUNCF_IsTxOlnpOk-s6AZgAUrvo/6/4ZaJwwHBETxNBtB3_FfyCw/aHR0cHM6Ly9wYXkuZ29jYXJkbGVzcy5jb20vQUwwMDA0RDVBUzVQMUg).
+2. Una vez completado el proceso, **no tendrás que preocuparte de nada más**. La cuota se te cobrará automáticamente cada año en la misma fecha en la que hiciste el primer pago (GoCardless te mandará un aviso unos días antes de cada cargo).
+3. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo/a socio/a"**, adjuntando:
+    - Tu documento de identidad (DNI/NIE/pasaporte) escaneado
+    - Tu teléfono de contacto
+
+**Opción 2: Transferencia bancaria**
+
+1. Haz una **transferencia de 30€** a la cuenta **ES18 1491 0001 2230 0008 5378** indicando en el **asunto tu DNI/NIE/pasaporte** y en **destinatario Asociación Python España**
+2. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo/a socio/a"**, adjuntando:
+    - Tu documento de identidad (DNI/NIE/pasaporte) escaneado
+    - Tu teléfono de contacto
+    - El comprobante de pago
+
+Ten en cuenta que, si eliges esta opción, **deberás hacer la transferencia de la cuota anual cada año tú mismo/a manualmente** (te lo recordaremos).
+
+En ambos casos, en unos días la Junta Directiva aprobará tu solicitud y nos pondremos en contacto contigo. Si lo deseas, puedes solicitar una cuenta bajo el dominio **@es.python.org[^1]** confirmándolo en el correo de alta.
 
 ¡No olvides decir «¡Hola!» cuando nos escribas! Y si encima tienes un momento para presentarte y hablarnos un poco de ti, mejor :)
 
-[^1]: Durante la segunda mitad del año (julio-diciembre inclusive) el pago será de 15€.
-
-[^2]: Si no deseas domiciliar el pago, omite el IBAN. El próximo febrero te tocará pagar la cuota completa del año (¡te lo recordaremos!).
-
-[^3]: La cuenta @es.python.org te brindará acceso a todos los servicios habilitados en nuestro Workspace de Google, incluyendo 30GB personales en Drive.
+[^1]: La cuenta @es.python.org te brindará acceso a todos los servicios habilitados en nuestro Workspace de Google, incluyendo 30GB personales en Drive.
 
 ***
 
 ## Quiero renovar la cuota
-Si domiciliaste la cuota no necesitas hacer nada más. ¡Nos encargamos desde la asociación! Si no domiciliaste la cuota, hace falta que realices la transferencia correspondiente(*) a la cuenta de la asociación indicando en el   **asunto el número de socio o DNI/NIE** y **destinatario "Asociación Python España"**.
+Si realizaste el primer pago mediante domiciliación bancaria con GoCardless, no necesitas hacer nada más; se te cobrará la cuota todos los años de manera automática en la fecha en la que te diste de alta (GoCardless te avisará unos días antes del cargo).
 
-Después mándanos un correo a la dirección **alta@es.python.org**, **adjuntando copia/foto del comprobante de pago** e indicando en el **asunto "Renovación cuota"**.
+Si realizaste el pago manual por transferencia bancaria, deberás repetir el proceso cada año:
+1. Realiza la **transferencia de 30€** a la cuenta **ES18 1491 0001 2230 0008 5378** indicando en el **asunto tu DNI/NIE/pasaporte** y en **destinatario Asociación Python España**
+2. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con:
+    - **Asunto "Renovación de cuota"**
+    - Comprobante de pago
 
-Opcionalmente, incluye en el correo tu número IBAN y te añadiremos al proceso automatizado (te llegará el recibo el próximo febrero).
-
-Antes de renovar tu cuota, te invitamos a que domicilies el pago o acompases tu renovación manual a febrero, nos facilitarías mucho la gestión a la Asociación.
-
-## Quiero acompasar mi cuota con el resto de la Asociación
-
-Para acompasar tu cuota con el resto de la Asociación, sigue las instrucciones del apartado anterior e indica en el correo que **deseas que la próxima fecha de renovación sea la de la Asociación**. El próximo febrero esperaremos una transferencia por tu parte (y te enviaremos un correo recordatorio por si se te pasa) o se te pasará el recibo correspondiente si elegiste domiciliar el pago.
+Si quieres olvidarte de las renovaciones manuales, puedes solicitar el cambio a **domiciliación bancaria con GoCardless** escribiéndonos a [alta@es.python.org](mailto:alta@es.python.org).
 
 ## Datos adicionales
 
-Cuenta bancaria de la asociación:
+**Cuenta bancaria de la asociación:**
 
 Triodos BANK
 
@@ -52,9 +62,14 @@ IBAN: ES18 1491 0001 2230 0008 5378
 
 BIC/SWIFT: TRIOESMMXXX
 
+
+**Servicio de domiciliación automática de la asociación:**
+
+[GoCardless de Python España](http://xih15.mjt.lu/lnk/AWMAADy7QSIAAcp9VNgAAdoxPfQAAYCr4qMAJgaEABTcwABmG6LGEUNCF_IsTxOlnpOk-s6AZgAUrvo/6/4ZaJwwHBETxNBtB3_FfyCw/aHR0cHM6Ly9wYXkuZ29jYXJkbGVzcy5jb20vQUwwMDA0RDVBUzVQMUg)
+
 ## Quiero darme de baja
 
-Es una pena dejar de contar contigo, y nos encantará que vuelvas a la Asociación Python España cuando quieras. Para darte de baja tienes que enviar un correo a **contacto@es.python.org** indicando que te quieres dar de baja. Desde ese momento no te pasaremos ninguna domiciliación y te daremos de baja de los canales de socias y socios (actualmente la lista de correo y el grupo de Telegram). Aparte, te agradeceríamos si nos dijeras el motivo de tu baja, o qué te haría volver en un futuro.
+Es una pena dejar de contar contigo, y nos encantará que vuelvas a la Asociación Python España cuando quieras. Para darte de baja tienes que enviar un correo a contacto@es.python.org indicando que te quieres dar de baja. Desde ese momento no te pasaremos ninguna domiciliación y te daremos de baja de los canales de socias y socios (actualmente la lista de correo y el grupo de Telegram). Aparte, te agradeceríamos si nos dijeras el motivo de tu baja, o qué te haría volver en un futuro.
 
 ## Notas generales
 
@@ -62,4 +77,4 @@ Es una pena dejar de contar contigo, y nos encantará que vuelvas a la Asociaci�
 - El correo electrónico puede servir como parte de la verificación de identidad de los usuarios para acceso a una plataforma, donde por ejemplo, pueda verificar que su solicitud ha sido tramitada.
 - El pago de la cuota es anual. Si pasados tres meses, no se ha producido el pago de la cuota correspondiente, se dará de baja al socio de forma automática.
 - Si necesitas un certificado de pago de la cuota, por favor háznoslo saber, tanto para un alta nueva, como para una renovación, de forma que podamos enviártelo a tu correo electrónico.
-- En cumplimiento de lo dispuesto en la Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal, Python España, le informa que los datos personales que nos sean proporcionados van a ser incorporados para su tratamiento en ficheros automatizados. La recogida y tratamiento de dichos datos tienen como finalidad gestión de socios, comunicaciones electrónicas y/o la confección de estadísticas. Python España se compromete al cumplimiento de su obligación de secreto con respecto a los datos de carácter personal suministrados y al deber de tratarlos con confidencialidad y reserva, conforme a la legislación vigente. A estos efectos adoptará las medidas necesarias para evitar su alteración, pérdida, tratamiento o acceso no autorizado. Así mismo se le informa que, si lo desea puede ejercitar los derechos previstos en el Art. 5 de la Ley a través del correo electrónico **socios@es.python.org**, seleccionando como asunto LOPD e indicando su nombre completo, su DNI y el tipo de derecho que desea ejercitar, Acceso, Rectificación, Cancelación u Oposición.
+- En cumplimiento de lo dispuesto en la Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal, Python España, le informa que los datos personales que nos sean proporcionados van a ser incorporados para su tratamiento en ficheros automatizados. La recogida y tratamiento de dichos datos tienen como finalidad gestión de socios, comunicaciones electrónicas y/o la confección de estadísticas. Python España se compromete al cumplimiento de su obligación de secreto con respecto a los datos de carácter personal suministrados y al deber de tratarlos con confidencialidad y reserva, conforme a la legislación vigente. A estos efectos adoptará las medidas necesarias para evitar su alteración, pérdida, tratamiento o acceso no autorizado. Así mismo se le informa que, si lo desea puede ejercitar los derechos previstos en el Art. 5 de la Ley a través del correo electrónico contacto@es.python.org, seleccionando como asunto LOPD e indicando su nombre completo, su DNI y el tipo de derecho que desea ejercitar, Acceso, Rectificación, Cancelación u Oposición.


### PR DESCRIPTION
Se actualizan las opciones de pago de cuota de socies, añadiendo y priorizando la opción de usar GoCardless.